### PR TITLE
Brew the imagination of the logic

### DIFF
--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,4 +1,4 @@
-name: Re Update Deps
+name: Rerun Update Deps
 
 on:
   repository_dispatch:
@@ -10,15 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Print condition
-        run: echo ${{ toJson(github.event.client_payload) }}
+        run: echo ${{ github.event.client_payload.pull_request }}
 
   update-deps:
     name: Rerun Auto Update Dependencies
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.client_payload.pull_request.labels, 'dependencies') && startsWith( github.event.client_payload.pull_request.title, '[scheduled]' ) }}
+    if: ${{ contains(github.event.client_payload.pull_request.labels.*.name, 'dependencies') && startsWith( github.event.client_payload.pull_request.title, '[scheduled]' ) }}
     steps:
-      - name: Install hub cli
-        uses: geertvdc/setup-hub@v1.0.0
       - name: Set up Go 1.14
         uses: actions/setup-go@v2
         with:
@@ -26,17 +24,19 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.client_payload.pull_request.head.ref }}
+        run: |
+          git clone $REPOSITORY
+          git fetch origin pull/$PULLNUMBER/head:update-deps
+        env:
+          - REPOSITORY: ${{ github.event.client_payload.github.repository.clone_url }}
+          - PULLNUMBER: ${{ github.event.client_payload.pull_request.number }}
 
       - name: Run update sh
         run: |
           git config user.email "tom.24d.en@gmail.com"
           git config user.name "Tomoya Nishide bot"
-          git checkout -b update-deps
+          git checkout update-deps
+          git rebase master
           export PATH=$PATH:/home/runner/work/bin
           ./hack/update-deps.sh --upgrade && ./hack/update-codegen.sh
           git add .
@@ -46,6 +46,6 @@ jobs:
 
       - name: force-push commit
         run: |
-          hub push -f origin update-deps
+          git push -f origin update-deps
         env:
           GITHUB_TOKEN: ${{ secrets.UPDATE_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ This plugin creates a controller to watch TaskRun/Pod(TBD), then send CloudEvent
 
 Supported CloudEvents event type are:
 ```
-dev.tekton.event.step.started.v1  
-dev.tekton.event.step.failed.v1
-dev.tekton.event.step.succeeded.v1
-dev.tekton.event.step.skipped.v1
+dev.tekton.event.plugin.step.started.v1  
+dev.tekton.event.plugin.step.failed.v1
+dev.tekton.event.plugin.step.succeeded.v1
+dev.tekton.event.plugin.step.skipped.v1
 ```
 
 The shape of CloudEvent data is:

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,15 +7,17 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 
+	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
 	taskruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/taskrun"
 )
 
-func NewController (ctx context.Context, cm configmap.Watcher) *controller.Impl {
+func NewController(ctx context.Context, cm configmap.Watcher) *controller.Impl {
 	logger := logging.FromContext(ctx)
 	taskrunInformer := taskruninformer.Get(ctx)
 
 	r := &Reconciler{
 		taskRunLister: taskrunInformer.Lister(),
+		pipelineClient: pipelineclient.Get(ctx),
 	}
 
 	impl := controller.NewImpl(r, logger, "my-controller")

--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -2,19 +2,51 @@ package controller
 
 import (
 	"context"
+	"go.uber.org/zap"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+
 
 	"knative.dev/pkg/logging"
 
+	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
+
+	stepevent "github.com/tom24d/step-observe-controller/pkg/event/step"
 )
 
 type Reconciler struct {
-	taskRunLister listers.TaskRunLister
+	taskRunLister  listers.TaskRunLister
+	pipelineClient clientset.Interface
 }
 
+// Reconcile reconciles taskrun resource for emitting CloudEvents.
+// This reconciler does not change any spec/status. All info is stored as json in the metadata.annotation
 func (r Reconciler) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
-	logger.Infof("Hello reconciler. key: %v", key)
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		logger.Errorf("invalid resource key: %s", zap.Any("key", key))
+	}
+
+	taskrun, ok := r.taskRunLister.TaskRuns(namespace).Get(name)
+	if apierrors.IsNotFound(ok) {
+		logger.Error("could not find taskrun", zap.Any("key", key))
+		return nil
+	} else if ok != nil {
+		return err
+	}
+
+	taskrun = taskrun.DeepCopy()
+
+	reconcileErr := stepevent.ReconcileStepEvent(ctx, taskrun, r.pipelineClient.TektonV1beta1().TaskRuns(namespace))
+	if reconcileErr != nil {
+		logger.Warn("Error reconciling TaskRun for step observer:", zap.Error(reconcileErr))
+	} else {
+		logger.Debug("TaskRun reconciled for step observer")
+		// consider emitting k8s event to record failures of CloudEvent emission.
+	}
 
 	return nil
 }

--- a/pkg/event/step/reconciler.go
+++ b/pkg/event/step/reconciler.go
@@ -1,0 +1,128 @@
+package step
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"k8s.io/apimachinery/pkg/types"
+
+	"knative.dev/pkg/logging"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v1beta1client "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/typed/pipeline/v1beta1"
+
+	"github.com/tom24d/step-observe-controller/pkg/event/step/resources"
+)
+
+const (
+	annotationKey = "tom24d.plugin.step-observer/result"
+)
+
+// ReconcileStepEvent actually reconciles taskrun to determine whether it should emit CloudEvent.
+// TODO maybe it has to watch Pod also and GET about step container spec&status directly.
+func ReconcileStepEvent(ctx context.Context, taskrun *v1beta1.TaskRun, client v1beta1client.TaskRunInterface) error {
+	logger := logging.FromContext(ctx)
+	if taskrun.Status.TaskSpec == nil ||
+		len(taskrun.Status.TaskSpec.Steps) < 1 {
+		logger.Infof("step event emission skipped as no step in taskrun: %s", taskrun.Name)
+		return nil
+	}
+
+	sent, err := initializeAnnotation(taskrun)
+	if err != nil {
+		logger.Fatalf("failed to initialize annotation: %v", err)
+		return nil
+	}
+
+
+	for i, step := range taskrun.Status.Steps {
+		// no emission if already sent
+
+		// start
+		if step.ContainerState.Running != nil {
+			// (Running) emit&mark started if i=0
+			if i == 0 {
+				ensureEventEmitted(ctx, sent, step.Name, resources.CloudEventTypeStepStarted)
+			}
+		}
+		// emit&mark started if i!=0 && i-1 step marked as succeeded
+		if i != 0 && sent.IsMarked(taskrun.Status.Steps[i-1].Name, resources.CloudEventTypeStepSucceeded) {
+			ensureEventEmitted(ctx, sent, step.Name, resources.CloudEventTypeStepStarted)
+		}
+
+		if step.ContainerState.Terminated != nil {
+			// skipped
+			// (Terminated) emit&mark skipped if i!=0 && i-1 step marked as failed||skipped,
+			// then continue to avoid being considered as failure
+			if i != 0 &&
+				(sent.IsMarked(taskrun.Status.Steps[i-1].Name, resources.CloudEventTypeStepFailed) ||
+					sent.IsMarked(taskrun.Status.Steps[i-1].Name, resources.CloudEventTypeStepSkipped)) {
+				ensureEventEmitted(ctx, sent, step.Name, resources.CloudEventTypeStepSkipped)
+				continue
+			}
+			// succeeded
+			// (Terminated) emit&mark succeeded if exit code is 0
+			if step.Terminated.ExitCode == 0 {
+				ensureEventEmitted(ctx, sent, step.Name, resources.CloudEventTypeStepSucceeded)
+			} else {
+				// failure
+				// (Terminated) emit&mark failed if exit code is not 0
+				ensureEventEmitted(ctx, sent, step.Name, resources.CloudEventTypeStepFailed)
+			}
+
+		}
+
+		// otherwise, no idea
+	}
+
+	// TODO PATCH for updated annotation at last
+	data, _ := sent.MarshalString()
+	tr := v1beta1.TaskRun{}
+	tr.Annotations = make(map[string]string)
+	tr.Annotations[annotationKey] = data
+	// TODO error handling
+	patch, _ := json.Marshal(tr)
+	logger.Infof("updated annotationKey: %s", sent)
+	_, err = client.Patch(taskrun.Name, types.MergePatchType, patch)
+	if err != nil {
+		logger.Errorf("patch error: %v", err)
+	}
+	return nil
+}
+
+func ensureEventEmitted(
+	ctx context.Context,
+	annotation *resources.CloudEventSent,
+	stepName string,
+	eventType resources.CloudEventType) *resources.CloudEventSent {
+
+	logger := logging.FromContext(ctx)
+	if !annotation.IsMarked(stepName, eventType) {
+		logger.Infof("EVENT EMISSION for step: %s, type: %v", stepName, eventType)
+		annotation, err := annotation.MarkEvent(ctx, stepName, eventType)
+		if err != nil {
+			logger.Fatalf("error occured at step: %v", err)
+		}
+		return annotation
+	}
+	return annotation
+}
+
+func initializeAnnotation(run *v1beta1.TaskRun) (*resources.CloudEventSent, error) {
+	annotation := &resources.CloudEventSent{}
+	if val, ok := run.Annotations[annotationKey]; ok {
+		err := resources.UnmarshalString(val, annotation)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal annotation: %v", err)
+		}
+		return annotation, nil
+	}
+
+	steps := run.Status.TaskSpec.Steps
+	for _, step := range steps {
+		r := resources.Reported{StepName: step.Name, ReportedType: make([]resources.CloudEventType, 0, 2)}
+		annotation.Steps = append(annotation.Steps, r)
+	}
+
+	return annotation, nil
+}

--- a/pkg/event/step/resources/cloudevents.go
+++ b/pkg/event/step/resources/cloudevents.go
@@ -1,0 +1,10 @@
+package resources
+
+type CloudEventType string
+
+const (
+	CloudEventTypeStepStarted   CloudEventType = "dev.tekton.event.plugin.step.started.v1"
+	CloudEventTypeStepFailed    CloudEventType = "dev.tekton.event.plugin.step.failed.v1"
+	CloudEventTypeStepSucceeded CloudEventType = "dev.tekton.event.plugin.step.succeeded.v1"
+	CloudEventTypeStepSkipped   CloudEventType = "dev.tekton.event.plugin.step.skipped.v1"
+)

--- a/pkg/event/step/resources/reported.go
+++ b/pkg/event/step/resources/reported.go
@@ -1,0 +1,71 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"knative.dev/pkg/logging"
+)
+
+type CloudEventSent struct {
+	Steps []Reported
+}
+
+func (s CloudEventSent) MarshalString() (string, error) {
+	data, err := json.Marshal(s)
+	return string(data), err
+}
+
+func UnmarshalString(str string, reported *CloudEventSent) error {
+	return json.Unmarshal([]byte(str), reported)
+}
+
+func (s *CloudEventSent) MarkEvent(ctx context.Context, stepName string, eventType CloudEventType) (*CloudEventSent, error) {
+	logger := logging.FromContext(ctx)
+	logger.Infof("MarkEvent() for %s", stepName)
+	logger.Infof("EventType: %s", eventType)
+	logger.Infof("EventType: %v", eventType)
+
+	for i, step := range s.Steps {
+		if step.StepName == stepName {
+			s.Steps[i].ReportedType = append(step.ReportedType, eventType)
+			logger.Infof("MarkEvent() marked as %v", s)
+			return s, nil
+		}
+	}
+
+	return nil, fmt.Errorf("step: %s not found. could not mark event: %v to %v", stepName, eventType, s.Steps)
+}
+
+func (s *CloudEventSent) IsMarked(stepName string, eventType CloudEventType) bool {
+	for _, step := range s.Steps {
+		if step.StepName == stepName {
+			return step.HasCloudEventType(eventType)
+		}
+	}
+	return false // When no stepName step contained
+}
+
+func (s *CloudEventSent) GetReported(stepName string) (*Reported, error) {
+	for _, step := range s.Steps {
+		if step.StepName == stepName {
+			return &step, nil
+		}
+	}
+	return nil, fmt.Errorf("no reported struct contained")
+}
+
+type Reported struct {
+	StepName     string           `json:"stepName"`
+	ReportedType []CloudEventType `json:"reportedType"`
+}
+
+func (r *Reported) HasCloudEventType(eventType CloudEventType) bool {
+	for _, s := range r.ReportedType {
+		if s == eventType {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
fed Task:
```
  steps:
    - name: hello1
      image: ubuntu
      command:
        - echo
      args:
        - "Hello World! ver 1"
    - name: hello2
      image: ubuntu
      command:
        - exit
      args:
        - "111"
    - name: hello3
      image: ubuntu
      command:
        - echo
      args:
        - "Hello World! ver 2"
```

and its reported result on annotation field on TaskRun:
```
      tom24d.plugin.step-observer/result: '{"Steps":[
{"stepName":"hello1","reportedType":["dev.tekton.event.plugin.step.started.v1","dev.tekton.event.plugin.step.succeeded.v1"]},
{"stepName":"hello2","reportedType":["dev.tekton.event.plugin.step.started.v1","dev.tekton.event.plugin.step.failed.v1"]},
{"stepName":"hello3","reportedType":["dev.tekton.event.plugin.step.skipped.v1"]}]}'

```